### PR TITLE
fix: detectTitle raises YAMLParseError

### DIFF
--- a/src/folder-title.ts
+++ b/src/folder-title.ts
@@ -6,7 +6,7 @@ import { AFItem, FileItem, parseYaml, Vault } from 'obsidian';
 
 const detectTitle = (content: string) => {
     // First look into YAML Frontmatters
-    const yfmMatch = /---[\r\n]+(.+)[\r\n]+(---|\.\.\.)/s.exec(content);
+    const yfmMatch = /---[\r\n]+(.+?)[\r\n]+(---|\.\.\.)/s.exec(content);
     if (yfmMatch !== null) {
         const yamlStr = yfmMatch[1];
         const yfm = parseYaml(yamlStr);


### PR DESCRIPTION
## Problem

The plugin fails to detect the title of Markdown files containing YAML Front Matter and horizontal rules.

## Cause

In the detectTitle() function, the regular expression that extracts YAML Front Matter is the longest match,

so it incorrectly extracts lines with horizontal ruled lines (```---```) as being YAML Front Matter.

## Fixed Points

Fixed the regular expression from the longest match to the shortest match.